### PR TITLE
remove flag from version filter

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory.java
@@ -130,10 +130,7 @@ public class DefaultRepositorySystemSessionFactory
             new SimpleResolutionErrorPolicy( errorPolicy, errorPolicy | ResolutionErrorPolicy.CACHE_NOT_FOUND ) );
 
         session.setArtifactTypeRegistry( RepositoryUtils.newArtifactTypeRegistry( artifactHandlerManager ) );
-        if ( Boolean.parseBoolean( System.getProperty( "versionFilter", "" ) ) )
-        {
-            session.setVersionFilter( new HighestVersionFilter() );
-        }
+        session.setVersionFilter( new HighestVersionFilter() );
 
         LocalRepository localRepo = new LocalRepository( request.getLocalRepository().getBasedir() );
 


### PR DESCRIPTION
Remove the default-disabled feature flag from the version-filter patch.

The flag was added in case the patch didn't work as expected, but
in that case, users can always just fall back to a vanilla release of
Maven.

I think there are two good reasons to just enable the patch unconditionally:
1. As is, having this flag makes it difficult to use, since you always
    have to remember the flag, and if you forget, you're in for a couple of hours
    of downloading pom files.
2. Just patching the binary lets us swap out the Maven binary in IDEA as well,
    which means we get the benefit of this patch while resolving dependencies
    in the IDE. In contrast, there's no way to supply a flag to be used with the
    maven wrapper in a way that all IDE operations avoid downloading the
    unnecessary older versions.